### PR TITLE
Patch and tests for failing firstresult cases.

### DIFF
--- a/src/apluggy/_wrap.py
+++ b/src/apluggy/_wrap.py
@@ -102,7 +102,7 @@ inside Plugin_1.acontext()
 import asyncio
 import contextlib
 from dataclasses import dataclass
-from typing import Any, Generator, List, Optional
+from typing import Any, Coroutine, Generator, List, Optional
 
 from exceptiongroup import BaseExceptionGroup
 from pluggy import PluginManager as PluginManager_
@@ -116,6 +116,10 @@ class _AHook:
         async def call(*args, **kwargs):
             hook = getattr(self.pm.hook, name)
             coros = hook(*args, **kwargs)
+            if coros is None:
+                return
+            if isinstance(coros, Coroutine):
+                return await coros
             return await asyncio.gather(*coros)
 
         return call

--- a/tests/plugins/spec.py
+++ b/tests/plugins/spec.py
@@ -25,3 +25,13 @@ def context(arg1, arg2):
 @asynccontextmanager
 async def acontext(arg1, arg2):
     yield
+
+
+@hookspec(firstresult=True)
+async def func_firstresult():
+    pass
+
+
+@hookspec(firstresult=True)
+async def func_firstresult_noimpl():
+    pass

--- a/tests/plugins/test_call.py
+++ b/tests/plugins/test_call.py
@@ -24,12 +24,25 @@ class ClassPlugin:
     async def acontext(self, arg1, arg2):
         yield arg1 - arg2
 
+    @spec.hookimpl
+    async def func_firstresult(self):
+        return 0
+
 
 instance_plugin = ClassPlugin()
 
 
 def test_hook(pm: PluginManager):
     assert pm.hook.func(arg1=1, arg2=2) == [-1, -1, 3]
+
+
+async def test_ahook_firstresult(pm: PluginManager):
+    assert (await pm.ahook.func_firstresult()) == 0
+
+
+async def test_ahook_firstresult_noimpl(pm: PluginManager):
+    # smoke test
+    await pm.ahook.func_firstresult_noimpl()
 
 
 async def test_ahook(pm: PluginManager):


### PR DESCRIPTION
Thanks for creating this library. It's been very useful for me.

I encountered a couple of edge cases with the wrapper. When the `firstresult` option is used on an async hook, only one coro is returned. This failed when trying to `gather` the coros. I also saw an issue where an async hook was not implemented and pluggy returned `None`, which will obviously fail if it's awaited. This also happened with`firstresult`. I assume the non-firstresult case will return an empty list, but I just realized I didn't check that case.

I don't know if my proposed change is the optimal one, but if not, hopefully the test cases will help.