### PR TITLE
Deprecate `apluggy.asynccontextmanager` and `apluggy.contextmanager`

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,24 +73,12 @@ Import necessary packages of this example.
 
 ```python
 >>> import asyncio
+>>> from contextlib import asynccontextmanager, contextmanager
 >>> import apluggy as pluggy
->>> from apluggy import asynccontextmanager, contextmanager
 
 ```
 
 In this example, `apluggy` is imported with the alias `pluggy`.
-
-The decorators `asynccontextmanager` and `contextmanager` are imported from
-`apluggy`. They are wrappers of the decorators of the same names in the
-[contextlib package](https://docs.python.org/3/library/contextlib.html). The
-wrappers preserve the signatures of decorated functions, which are necessary for
-pluggy to pass arguments to hook implementations correctly. (The decorator
-`contextmanger` in `apluggy` is the same object as the decorator
-`contextmanager` in the [decorator
-package](https://pypi.org/project/decorator/). The decorator package does not
-provide `asynccontextmanager` decorator as of version 5.1. The decorator
-`asynccontextmanger` in `apluggy` is implemented in a similar way as the
-decorator `contextmanager` in the decorator package.)
 
 ### Create hook specification and implementation decorators
 
@@ -284,7 +272,6 @@ inside Plugin_1.acontext(): after
 ## Links
 
 - [pluggy](https://pluggy.readthedocs.io/)
-- [decorator](https://pypi.org/project/decorator/)
 
 ---
 

--- a/ci/latest/requirements.txt
+++ b/ci/latest/requirements.txt
@@ -2,7 +2,6 @@
 # is used in a GitHub Actions workflow to test the compatibility with the
 # latest versions of the dependencies. This file is monitored by Dependabot.
 pluggy==1.5.0
-decorator==5.1.1
 types-decorator==5.1.8.20250215
 pytest-asyncio==0.25.3
 pytest-cov==6.0.0

--- a/ci/minimum/requirements.txt
+++ b/ci/minimum/requirements.txt
@@ -2,7 +2,6 @@
 # This file is used in a GitHub Actions workflow to test the compatibility.
 # This file needs to be manually updated to be consistent with
 pluggy==1.3.0
-decorator==5.1.0
 types-decorator==5.1.0
 pytest-asyncio==0.18.0
 pytest-cov==3.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
 ]
 dependencies = [
   "pluggy>=1.3",
-  "decorator>=5.1",
   "types-decorator>=5.1",
   "typing_extensions>=4.12; python_version < '3.10'",
 ]

--- a/src/apluggy/__init__.py
+++ b/src/apluggy/__init__.py
@@ -11,9 +11,8 @@ __all__ = [
 ]
 
 
-from decorator import contextmanager
 from pluggy import HookCallError, HookimplMarker, HookspecMarker, PluginValidationError
 
-from ._decorator import asynccontextmanager
+from ._decorator import asynccontextmanager, contextmanager
 from .stack import async_stack_gen_ctxs, stack_gen_ctxs
 from .wrap import PluginManager

--- a/src/apluggy/_decorator.py
+++ b/src/apluggy/_decorator.py
@@ -2,13 +2,22 @@ __all__ = ['asynccontextmanager']
 
 import warnings
 from contextlib import asynccontextmanager as _asynccontextmanager
+from contextlib import contextmanager as _contextmanager
 
 
 def asynccontextmanager(func):
-
     warnings.warn(
         'apluggy.asynccontextmanager is now the same as contextlib.asynccontextmanager',
         DeprecationWarning,
         stacklevel=2,
     )
     return _asynccontextmanager(func)
+
+
+def contextmanager(func):
+    warnings.warn(
+        'apluggy.contextmanager is now the same as contextlib.contextmanager',
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _contextmanager(func)

--- a/src/apluggy/_decorator.py
+++ b/src/apluggy/_decorator.py
@@ -1,68 +1,14 @@
-'''Implement asynccontextmanager in the same way as decorator.contextmanager.
-
-decorator: https://pypi.org/project/decorator/
-
-
->>> import asyncio
->>> import inspect
->>> import contextlib
->>> from apluggy import asynccontextmanager
-
-With the original `asynccontextmanager` from `contextlib`:
-
->>> @contextlib.asynccontextmanager
-... async def context(arg1, arg2):
-...     yield arg1 + arg2
-
-the arguments signature becomes `(*args, **kwds)`:
-
->>> inspect.getfullargspec(context)
-FullArgSpec(args=[], varargs='args', varkw='kwds', ...)
-
-
-With the `asynccontextmanager` from this module:
-
->>> @asynccontextmanager
-... async def context(arg1, arg2):
-...     yield arg1 + arg2
-
-the arguments signature is preserved:
-
->>> inspect.getfullargspec(context)
-FullArgSpec(args=['arg1', 'arg2'], varargs=None, varkw=None, ...)
-
-It runs as expected:
-
->>> async def main():
-...     async with context(1, 2) as result:
-...         print(result)
-...
->>> asyncio.run(main())
-3
-
-'''
-
 __all__ = ['asynccontextmanager']
 
-import contextlib
-
-from decorator import decorate, decorator
-
-
-class AsyncContextManager(contextlib._AsyncGeneratorContextManager):
-    def __init__(self, g, *a, **k):
-        super().__init__(g, a, k)
-
-    def __call__(self, func):  # pragma: no cover
-        async def caller(f, *a, **k):
-            async with self.__class__(self.func, *self.args, **self.kwds):
-                return f(*a, **k)
-
-        return decorate(func, caller)
-
-
-_asynccontextmanager = decorator(AsyncContextManager)
+import warnings
+from contextlib import asynccontextmanager as _asynccontextmanager
 
 
 def asynccontextmanager(func):
+
+    warnings.warn(
+        'apluggy.asynccontextmanager is now the same as contextlib.asynccontextmanager',
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return _asynccontextmanager(func)

--- a/src/apluggy/wrap/main.py
+++ b/src/apluggy/wrap/main.py
@@ -17,7 +17,7 @@ class PluginManager(PluginManager_):
 
     >>> import asyncio
     >>> import apluggy as pluggy
-    >>> from apluggy import asynccontextmanager, contextmanager
+    >>> from contextlib import asynccontextmanager, contextmanager
 
     >>> hookspec = pluggy.HookspecMarker('project')
     >>> hookimpl = pluggy.HookimplMarker('project')

--- a/tests/plugins/module_plugin.py
+++ b/tests/plugins/module_plugin.py
@@ -1,4 +1,4 @@
-from apluggy import asynccontextmanager, contextmanager
+from contextlib import asynccontextmanager, contextmanager
 
 from . import spec
 

--- a/tests/plugins/spec.py
+++ b/tests/plugins/spec.py
@@ -1,5 +1,6 @@
+from contextlib import asynccontextmanager, contextmanager
+
 import apluggy as pluggy
-from apluggy import asynccontextmanager, contextmanager
 
 hookspec = pluggy.HookspecMarker('myproject')
 hookimpl = pluggy.HookimplMarker('myproject')

--- a/tests/plugins/test_call.py
+++ b/tests/plugins/test_call.py
@@ -1,6 +1,8 @@
+from contextlib import asynccontextmanager, contextmanager
+
 import pytest
 
-from apluggy import PluginManager, asynccontextmanager, contextmanager
+from apluggy import PluginManager
 
 from . import module_plugin, spec
 

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,11 +1,7 @@
+import pytest
 from pluggy._hooks import varnames
 
 from apluggy import asynccontextmanager, contextmanager
-
-
-@asynccontextmanager
-async def acontext(arg1, arg2):
-    yield arg1 + arg2
 
 
 @contextmanager
@@ -14,6 +10,11 @@ def context(arg1, arg2):
 
 
 async def test_acontext():
+    with pytest.deprecated_call():
+        @asynccontextmanager
+        async def acontext(arg1, arg2):
+            yield arg1 + arg2
+
     expected = (('arg1', 'arg2'), ())
     assert varnames(acontext) == expected
     async with acontext(1, 2) as result:

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -4,13 +4,9 @@ from pluggy._hooks import varnames
 from apluggy import asynccontextmanager, contextmanager
 
 
-@contextmanager
-def context(arg1, arg2):
-    yield arg1 + arg2
-
-
 async def test_acontext():
     with pytest.deprecated_call():
+
         @asynccontextmanager
         async def acontext(arg1, arg2):
             yield arg1 + arg2
@@ -22,6 +18,12 @@ async def test_acontext():
 
 
 async def test_context():
+    with pytest.deprecated_call():
+
+        @contextmanager
+        def context(arg1, arg2):
+            yield arg1 + arg2
+
     expected = (('arg1', 'arg2'), ())
     assert varnames(context) == expected
     with context(1, 2) as result:


### PR DESCRIPTION
The `contextlib.asynccontextmanager` and `contextlib.contextmanager` work since pluggy 1.2.0 with https://github.com/pytest-dev/pluggy/pull/359