### PR TITLE
Set `asyncio_default_fixture_loop_scope`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ tag_sign = false
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 timeout = 60
 addopts = """
 --doctest-modules


### PR DESCRIPTION
To suppress a warning as described in https://github.com/pytest-dev/pytest-asyncio/issues/924